### PR TITLE
fix: add YUYV format support for 640x480 to support more camera types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -844,7 +844,11 @@ fn device_supports_video_capture(path: &str) -> bool {
         return false;
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    stdout.contains("Video Capture")
+    stdout
+        .lines()
+        .skip_while(|l| !l.contains("Device Caps"))
+        .take(10)
+        .any(|l| l.contains("Video Capture"))
 }
 
 pub fn print_help() -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,6 +602,12 @@ impl V4l2OpenCamera {
                 width: 640,
                 height: 480,
                 fps: 30,
+                format: *b"YUYV",
+            },
+            CapturePreset {
+                width: 640,
+                height: 480,
+                fps: 30,
                 format: *b"MJPG",
             },
         ];


### PR DESCRIPTION
Some webcams (like the HP Integrated Webcam) only support YUYV format at 640x480 resolution. Previously, the code only tried MJPG format at this resolution, which failed on these cameras with:

```
failed to start V4L2 stream on /dev/video0. Last attempted mode: 640x480@30 MJPG rejected by /dev/video0: Invalid or unsupported format of pixels
```

This PR adds YUYV as a fallback before MJPG for 640x480 resolution, fixing compatibility with:

- HP Integrated Webcam and similar older webcams
- Any camera that does not support MJPG at lower resolutions

## Test results
The fix was tested and confirmed working:

```
$ aeyes frame --camera 0 -o test-frame.jpg
Daemon started with PID 99603 at http://127.0.0.1:43210 using camera 0 (HP Integrated Webcam)
Saved frame to test-frame.jpg

$ file test-frame.jpg
JPEG image data, JFIF standard 1.02, 640x480, components 3
```